### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Signs of a Potentially Scammy Bug Bounty Program:
 | **[Cimpress](https://cimpress.com/privacy-security/)** | Bounty Roulette<sup>11</sup> | Self hosted | Trusted Hacker | 2
 | **[Swiggy](https://www.swiggy.com/bug-bounty)** | No rewards<sup>1</sup> | Self hosted | Trusted Hacker | 1
 | **[SignageOS](https://www.signageos.io/legal/bug-bounty)** | No rewards<sup>1</sup> | Self hosted | Trusted Hacker | 1
- |**[Parity Technologies](https://www.parity.io/bug-bounty)** | Ignored reports<sup>2</sup> | Self hosted |Trusted hacker        | 1
+| **[Parity Technologies](https://www.parity.io/bug-bounty)** | Ignored reports<sup>2</sup> | Self hosted |Trusted hacker | 1
+| **[Lark Technologies](https://hackerone.com/lark_technologies)** | Ignored reports<sup>2</sup> | Hackerone |Trusted hacker | 1
 
 ## Hackerone
 


### PR DESCRIPTION
Add Lark Technologies to the list because they marked my three valid reports as informative even though the impact is clear (an attacker can view, edit, and delete data inside a folder despite permission restrictions). On the other hand, they do not allow me to disclose my reports.